### PR TITLE
AKBUNDELS-281

### DIFF
--- a/src/Component/Statement/EqualsStatement.php
+++ b/src/Component/Statement/EqualsStatement.php
@@ -10,6 +10,8 @@ class EqualsStatement implements PredeterminedStatementInterface
 
     private function whenField(Field $field, array $item): bool
     {
+        $field->repopulateFromItem($item);
+
         return
             isset($item[$field->getField()]) &&
             is_string($item[$field->getField()]) &&

--- a/src/Component/Statement/Field.php
+++ b/src/Component/Statement/Field.php
@@ -9,8 +9,15 @@ class Field
 
     public function __construct(string $field, string $value = null)
     {
-        $this->field = $field;
+        $this->field = str_replace(['{','}'], '', $field); # for legacy reasons we can't replace this value here yet
         $this->value = $value;
+    }
+
+    public function repopulateFromItem(array $item): void
+    {
+        if ($this->value !== str_replace(['{','}'], '', $this->value)) {
+            $this->value = ItemPlaceholder::replace($this->value, $item);
+        }
     }
 
     public function getField(): string

--- a/src/Component/Statement/GreaterThanOrEqualStatement.php
+++ b/src/Component/Statement/GreaterThanOrEqualStatement.php
@@ -10,6 +10,8 @@ class GreaterThanOrEqualStatement implements PredeterminedStatementInterface
 
     private function whenField(Field $field, array $item): bool
     {
+        $field->repopulateFromItem($item);
+
         return
             isset($item[$field->getField()]) &&
             is_numeric($item[$field->getField()]) &&

--- a/src/Component/Statement/GreaterThanStatement.php
+++ b/src/Component/Statement/GreaterThanStatement.php
@@ -2,9 +2,9 @@
 
 namespace Misery\Component\Statement;
 
-class NotEqualStatement implements PredeterminedStatementInterface
+class GreaterThanStatement implements PredeterminedStatementInterface
 {
-    public const NAME = 'NOT_EQUAL';
+    public const NAME = 'GREATER_THAN';
 
     use StatementTrait;
 
@@ -14,8 +14,8 @@ class NotEqualStatement implements PredeterminedStatementInterface
 
         return
             isset($item[$field->getField()]) &&
-            is_string($item[$field->getField()]) &&
-            $item[$field->getField()] !== $field->getValue()
+            is_numeric($item[$field->getField()]) &&
+            $item[$field->getField()] > $field->getValue()
         ;
     }
 }

--- a/src/Component/Statement/ItemPlaceholder.php
+++ b/src/Component/Statement/ItemPlaceholder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Misery\Component\Statement;
+
+class ItemPlaceholder
+{
+    public static function replace(string $text, array $item): array|string|null
+    {
+        return preg_replace_callback('/\{(\w+)\}/', function ($matches) use ($item) {
+            // $matches[1] is the key inside the brackets
+            return isset($item[$matches[1]]) ? $item[$matches[1]] : $matches[0];
+        }, $text);
+    }
+}

--- a/src/Component/Statement/SmallerThanOrEqualStatement.php
+++ b/src/Component/Statement/SmallerThanOrEqualStatement.php
@@ -2,9 +2,9 @@
 
 namespace Misery\Component\Statement;
 
-class NotEqualStatement implements PredeterminedStatementInterface
+class SmallerThanOrEqualStatement implements PredeterminedStatementInterface
 {
-    public const NAME = 'NOT_EQUAL';
+    public const NAME = 'SMALLER_THAN_OR_EQUAL_TO';
 
     use StatementTrait;
 
@@ -14,8 +14,8 @@ class NotEqualStatement implements PredeterminedStatementInterface
 
         return
             isset($item[$field->getField()]) &&
-            is_string($item[$field->getField()]) &&
-            $item[$field->getField()] !== $field->getValue()
+            is_numeric($item[$field->getField()]) &&
+            $item[$field->getField()] <= $field->getValue()
         ;
     }
 }

--- a/src/Component/Statement/SmallerThanStatement.php
+++ b/src/Component/Statement/SmallerThanStatement.php
@@ -2,9 +2,9 @@
 
 namespace Misery\Component\Statement;
 
-class NotEqualStatement implements PredeterminedStatementInterface
+class SmallerThanStatement implements PredeterminedStatementInterface
 {
-    public const NAME = 'NOT_EQUAL';
+    public const NAME = 'SMALLER_THAN';
 
     use StatementTrait;
 
@@ -14,8 +14,8 @@ class NotEqualStatement implements PredeterminedStatementInterface
 
         return
             isset($item[$field->getField()]) &&
-            is_string($item[$field->getField()]) &&
-            $item[$field->getField()] !== $field->getValue()
+            is_numeric($item[$field->getField()]) &&
+            $item[$field->getField()] < $field->getValue()
         ;
     }
 }

--- a/src/Component/Statement/StatementBuilder.php
+++ b/src/Component/Statement/StatementBuilder.php
@@ -30,6 +30,18 @@ class StatementBuilder
             case 'GREATER_THAN_OR_EQUAL_TO':
                 $statement = GreaterThanOrEqualStatement::prepare(new SetValueAction());
                 break;
+            case '>':
+            case 'GREATER_THAN':
+                $statement = GreaterThanStatement::prepare(new SetValueAction());
+                break;
+            case '<=':
+            case 'SMALLER_THAN_OR_EQUAL_TO':
+                $statement = SmallerThanOrEqualStatement::prepare(new SetValueAction());
+                break;
+            case '<':
+            case 'SMALLER_THAN':
+                $statement = SmallerThanStatement::prepare(new SetValueAction());
+                break;
             case '!=':
             case 'NOT_EQUAL':
                 $statement = NotEqualStatement::prepare(new SetValueAction());
@@ -113,6 +125,14 @@ class StatementBuilder
         if (count($containsFields) === 2) {
             $statement = ContainsStatement::prepare(new SetValueAction());
             $statement->when($containsFields[0], $containsFields[1]);
+
+            return $statement;
+        }
+
+        if (count($andFields) === 1) {
+            $fields = explode(' ', $whenString);
+            $statement = self::buildFromOperator($fields[1], $context);
+            $statement->when($fields[0], $fields[2] ?? null);
         }
 
         return $statement;

--- a/tests/Component/Action/StatementActionTest.php
+++ b/tests/Component/Action/StatementActionTest.php
@@ -232,4 +232,121 @@ class StatementActionTest extends TestCase
 
         $this->assertEquals($item, $format->apply($item));
     }
+
+    public function test_it_should_compare_with_different_operators(): void
+    {
+        $format = new StatementAction();
+
+        $item = [
+            'correct' => 'FALSE',
+            'number_high' => '10',
+            'number_low' => '1',
+            'number_calc' => '10',
+            'sku' => '1',
+        ];
+
+        $format->setOptions([
+            'when' => '{number_high} GREATER_THAN {number_low}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('TRUE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_low} GREATER_THAN {number_high}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('FALSE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_high} GREATER_THAN_OR_EQUAL_TO {number_calc}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('TRUE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_high} <= {number_calc}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('TRUE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_low} < {number_high}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('TRUE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_high} > {number_low}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('TRUE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_low} > {number_high}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('FALSE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_calc} >= {number_high}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('TRUE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_low} <= {number_high}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('TRUE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_calc} == {number_high}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('TRUE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_low} < {number_high} AND {number_calc} == {number_high}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('TRUE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_low} != {number_high}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('TRUE', $format->apply($item)['correct']);
+
+        $format->setOptions([
+            'when' => '{number_low} == {number_high}',
+            'then' => [
+                'correct' => 'TRUE',
+            ],
+        ]);
+        $this->assertSame('FALSE', $format->apply($item)['correct']);
+    }
 }


### PR DESCRIPTION
```php
        $item = [
            'correct' => 'FALSE',
            'number_high' => '10',
            'number_low' => '1',
            'number_calc' => '10',
            'sku' => '1',
        ];
 ```

**OPERATORS**

`GREATER_THAN, GREATER_THAN_OR_EQUAL_TO, SMALLER_THAN, SMALLER_THAN_OR_EQUAL_TO, NOT_EQUAL, EQUALS
`

`>, >=, ==, <=, <, !=
` 

**USAGE**

```yaml
when: '{number_high} GREATER_THAN {number_low}'
then: ...
 ```

- [x] {values} mustache values are limited to these statement operators 