### PR TITLE
✨ feat(VDS): add new converters for Akeneo Assets and Reference Entities

### DIFF
--- a/src/Component/Action/ArrayValueAction.php
+++ b/src/Component/Action/ArrayValueAction.php
@@ -15,6 +15,7 @@ class ArrayValueAction implements OptionsInterface
         'field' => null,
         'column_item' => null,
         'function' => null,
+        'separator' => ' ',
     ];
 
     public function apply(array $item): array
@@ -28,6 +29,17 @@ class ArrayValueAction implements OptionsInterface
                 break;
             case 'array_merge':
                 $item = $this->arrayMerge($item, $field, $columnItem);
+                break;
+            case 'array_values_with_keys':
+                $item = array_merge($item, $item[$columnItem] ?? []);
+                break;
+            case 'array_keys':
+                $item[$field] =  array_keys($item[$columnItem]) ?? [];
+                break;
+            case 'array_filter':
+                $item[$field] = array_filter($item[$columnItem] ?? [], function ($value) {
+                    return $value !== "" && $value !== null && $value !== false && $value !== [];
+                });
                 break;
             default:
                 throw new \Exception('Function not found');

--- a/src/Component/Converter/Akeneo/Api/Assets.php
+++ b/src/Component/Converter/Akeneo/Api/Assets.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace Misery\Component\Converter\Akeneo\Api;
+
+use Misery\Component\Common\Options\OptionsInterface;
+use Misery\Component\Common\Options\OptionsTrait;
+use Misery\Component\Common\Registry\RegisteredByNameInterface;
+use Misery\Component\Converter\AkeneoCsvHeaderContext;
+use Misery\Component\Converter\ConverterInterface;
+
+class Assets implements ConverterInterface, RegisteredByNameInterface, OptionsInterface
+{
+    use OptionsTrait;
+
+    private $csvHeaderContext;
+    private $options = [
+        'list' => null,
+    ];
+
+    public function __construct(AkeneoCsvHeaderContext $csvHeaderContext)
+    {
+        $this->csvHeaderContext = $csvHeaderContext;
+    }
+
+    public function convert(array $item): array
+    {
+        $this->csvHeaderContext->unsetHeader();
+        $separator = '-';
+        $output = [];
+
+        foreach ($item as $key => $value) {
+            if (in_array($key, ['code', 'labels', '%asset_family_code%'])) {
+                continue;
+            }
+
+            $keys = explode($separator, $key);
+            # values
+            $prep = $this->csvHeaderContext->create($item)[$key];
+
+            $prep['channel'] = $prep['scope'];
+            unset($prep['scope']);
+
+            $prep['data'] = $value;
+            unset($prep['key']);
+
+            $output['values'][$keys[0]][] = $prep;
+            unset($item[$key]);
+        }
+
+        return $item+$output;
+    }
+
+    public function revert(array $item): array
+    {
+       return $item;
+    }
+
+    public function getName(): string
+    {
+        return 'akeneo/assets/api';
+    }
+}

--- a/src/Component/Converter/Akeneo/Api/ReferenceEntities.php
+++ b/src/Component/Converter/Akeneo/Api/ReferenceEntities.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace Misery\Component\Converter\Akeneo\Api;
+
+use Misery\Component\Common\Options\OptionsInterface;
+use Misery\Component\Common\Options\OptionsTrait;
+use Misery\Component\Common\Registry\RegisteredByNameInterface;
+use Misery\Component\Converter\AkeneoCsvHeaderContext;
+use Misery\Component\Converter\ConverterInterface;
+
+class ReferenceEntities implements ConverterInterface, RegisteredByNameInterface, OptionsInterface
+{
+    use OptionsTrait;
+
+    private $csvHeaderContext;
+    private $options = [
+        'list' => null,
+    ];
+
+    public function __construct(AkeneoCsvHeaderContext $csvHeaderContext)
+    {
+        $this->csvHeaderContext = $csvHeaderContext;
+    }
+
+    public function convert(array $item): array
+    {
+        $this->csvHeaderContext->unsetHeader();
+        $separator = '-';
+        $output = [];
+
+        foreach ($item as $key => $value) {
+            if (in_array($key, ['code', 'labels', '%reference-code%'])) {
+                continue;
+            }
+
+            $keys = explode($separator, $key);
+            # values
+            $prep = $this->csvHeaderContext->create($item)[$key];
+
+            $prep['channel'] = $prep['scope'];
+            unset($prep['scope']);
+
+            $prep['data'] = $value;
+            unset($prep['key']);
+
+            $output['values'][$keys[0]][] = $prep;
+            unset($item[$key]);
+        }
+
+        return $item+$output;
+    }
+
+    public function revert(array $item): array
+    {
+       return $item;
+    }
+
+    public function getName(): string
+    {
+        return 'akeneo/reference_entities/api';
+    }
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -49,6 +49,12 @@ $converterRegistry->registerAllByName(
     new Misery\Component\Converter\Akeneo\Api\Product(
         new Misery\Component\Converter\AkeneoCsvHeaderContext()
     ),
+    new Misery\Component\Converter\Akeneo\Api\ReferenceEntities(
+        new Misery\Component\Converter\AkeneoCsvHeaderContext()
+    ),
+    new Misery\Component\Converter\Akeneo\Api\Assets(
+        new Misery\Component\Converter\AkeneoCsvHeaderContext()
+    ),
     new Misery\Component\Converter\AkeneoFlatProductModelToCsvConverter(),
     new Misery\Component\Converter\AkeneoFlatProductToCsvConverter(),
     new Misery\Component\Converter\AkeneoFlatAttributeOptionsToCsv(),


### PR DESCRIPTION
Added `Assets` and `ReferenceEntities` classes to the Akeneo API component. These converters enhance data processing by allowing the conversion of assets and reference entities from Akeneo CSV format. This improves the overall flexibility and usability of the data handling process.