### PR TITLE
AKSERAX-38: StoreAction: added strict_value_matching

### DIFF
--- a/src/Component/Action/StoreAction.php
+++ b/src/Component/Action/StoreAction.php
@@ -4,11 +4,11 @@ namespace Misery\Component\Action;
 
 use App\Component\ChangeManager\ChangeSetLabelMaker;
 
+use Misery\Component\Common\Functions\ArrayFunctions;
 use Misery\Component\Common\Options\OptionsInterface;
 use Misery\Component\Common\Options\OptionsTrait;
 use Misery\Component\Configurator\ConfigurationAwareInterface;
 use Misery\Component\Configurator\ConfigurationTrait;
-use Misery\Component\Converter\Matcher;
 
 class StoreAction implements ActionInterface, OptionsInterface, ConfigurationAwareInterface
 {
@@ -18,19 +18,30 @@ class StoreAction implements ActionInterface, OptionsInterface, ConfigurationAwa
     public const PRODUCT_HAS_CHANGES = 'product_has_changes';
     public const DELETE_PRODUCT = 'delete_product';
     public const UPDATE_PRODUCT = 'update_product';
-    public const STORE_PRODUCT = 'store_product';
 
     public const NAME = 'store';
     public ItemActionProcessor $trueActionProcessor;
     public ItemActionProcessor $falseActionProcessor;
 
-    /** @var array */
-    private $options = [
-        'event' => null,
-        'identifier' => null,
-        'entity' => 'product',
+    private array $defaults = [
         'change_manager' => [
             'all_values' => true,
+            'values' => [],
+            'context' => [
+                'locales' => [],
+                'scope' => null,
+            ],
+        ],
+    ];
+
+    private $options = [
+        'event' => null,
+        'identifier' => 'identifier',
+        'entity' => 'product',
+        'store_product' => true,
+        'change_manager' => [
+            'all_values' => true,
+            'strict_value_matching' => true,
             'values' => [],
             'context' => [
                 'locales' => [],
@@ -55,6 +66,14 @@ class StoreAction implements ActionInterface, OptionsInterface, ConfigurationAwa
                 $this->falseActionProcessor = $this->configuration->generateActionProcessor($falseAction);
             }
             $this->setOption('init', true);
+
+            $this->setOption(
+                'change_manager',
+                ArrayFunctions::array_merge_recursive(
+                    $this->defaults['change_manager'],
+                    $this->getOption('change_manager')
+                )
+            );
         }
     }
 
@@ -70,6 +89,9 @@ class StoreAction implements ActionInterface, OptionsInterface, ConfigurationAwa
             return $item;
         }
         $changeManager = $this->configuration->changeManager;
+        if ($this->getOption('strict_value_matching') === false) {
+            $changeManager->disableStrictMatching();
+        }
 
         if ($event === self::PRODUCT_HAS_CHANGES) {
             $trueAction = $this->getOption('true_action');
@@ -83,15 +105,16 @@ class StoreAction implements ActionInterface, OptionsInterface, ConfigurationAwa
             } elseif (true === $changeManagerData['all_values'] && isset($item['values'])) {
                 $labels->addSubDomainProperties('values', array_keys($item['values']));
             }
-            if (isset($changeManagerData['context']['scope'])) {
+            if (!empty($changeManagerData['context']['scope'])) {
                 $labels->addScope($changeManagerData['context']['scope']);
             }
-            if (isset($changeManagerData['context']['locales'])) {
+            if (!empty($changeManagerData['context']['locales'])) {
                 $labels->addLocales($changeManagerData['context']['locales']);
             }
             $labels = $labels->build();
+            $productHasChanges = $changeManager->hasChanges($identifier, $item, $labels);
 
-            if ($changeManager->hasChanges($identifier, $item, $labels)) {
+            if ($productHasChanges) {
                 // start true_action
                 // make changes list
                 $changes = $changeManager->getChanges($identifier, $entity.'.values');
@@ -101,22 +124,18 @@ class StoreAction implements ActionInterface, OptionsInterface, ConfigurationAwa
                 $this->configuration->updateList('product_changes_fields_updated', $changes['updated']);
                 $this->configuration->updateList('product_changes_fields_all', $changes['all']);
 
-                // see GroupAction, get ActionProcessor, process your action(s)
-                if ([] !== $trueAction) {
-                    $item = $this->trueActionProcessor->process($item);
-                }
-
-                // see GroupAction, get actionProcessor, process your action(s)
-                if ([] !== $falseAction) {
-                    $item = $this->falseActionProcessor->process($item);
-                }
-
                 $this->storeProduct($identifier);
+            };
 
-                return $item;
+            // see GroupAction, get ActionProcessor, process your action(s)
+            if ($productHasChanges && [] !== $trueAction) {
+                $item = $this->trueActionProcessor->process($item);
             }
 
-            return [];
+            // see GroupAction, get actionProcessor, process your action(s)
+            if (!$productHasChanges && [] !== $falseAction) {
+                $item = $this->falseActionProcessor->process($item);
+            }
         }
 
         return $item;
@@ -124,6 +143,8 @@ class StoreAction implements ActionInterface, OptionsInterface, ConfigurationAwa
 
     private function storeProduct(string $identifier): void
     {
-        $this->configuration->changeManager->persistChange($identifier);
+        if ($this->getOption('store_product')) {
+            $this->configuration->changeManager->persistChange($identifier);
+        }
     }
 }

--- a/src/Component/Common/Functions/ArrayFunctions.php
+++ b/src/Component/Common/Functions/ArrayFunctions.php
@@ -202,6 +202,20 @@ class ArrayFunctions
         });
     }
 
+    public static function array_merge_recursive(array &$array1, array $array2) {
+        foreach ($array2 as $key => $value) {
+            // If the value is an array and the key exists in both arrays
+            if (is_array($value) && isset($array1[$key]) && is_array($array1[$key])) {
+                self::array_merge_recursive($array1[$key], $value);
+            } else {
+                // Overwrite the value in the first array
+                $array1[$key] = $value;
+            }
+        }
+
+        return $array1;
+    }
+
     public static function fill_with_empty(array $array): array
     {
         return array_fill_keys($array, null);

--- a/tests/Component/Action/StoreActionTest.php
+++ b/tests/Component/Action/StoreActionTest.php
@@ -16,6 +16,9 @@ class StoreActionTest extends TestCase
 
     protected function setUp(): void
     {
+        if (!class_exists(\App\Component\ChangeManager\ChangeManager::class)) {
+            $this->markTestSkipped('ChangeManager class does not exist.');
+        }
         $this->configuration = $this->createMock(Configuration::class);
         $this->changeManager = $this->createMock(ChangeManager::class);
 

--- a/tests/Component/Action/StoreActionTest.php
+++ b/tests/Component/Action/StoreActionTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Misery\Component\Action;
+
+use App\Component\ChangeManager\ChangeManager;
+use Misery\Component\Action\ItemActionProcessor;
+use Misery\Component\Action\StoreAction;
+use Misery\Component\Configurator\Configuration;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class StoreActionTest extends TestCase
+{
+    private Configuration|MockObject $configuration;
+    private ChangeManager|MockObject $changeManager;
+
+    protected function setUp(): void
+    {
+        $this->configuration = $this->createMock(Configuration::class);
+        $this->changeManager = $this->createMock(ChangeManager::class);
+
+        $this->configuration->changeManager = $this->changeManager;
+    }
+
+    public function testDetectAddedChanges()
+    {
+        $item = [
+            'identifier' => '123',
+            'values' => ['name' => 'New Product'],
+        ];
+
+        $this->changeManager->method('hasChanges')->willReturn(true);
+        $this->changeManager->method('getChanges')->willReturn([
+            'added' => ['name'],
+            'deleted' => [],
+            'updated' => [],
+            'all' => ['name'],
+        ]);
+
+        $this->configuration
+            ->method('updateList')
+            ->willReturnCallback(function (...$args) use (&$calls) {
+                $calls[] = $args;
+            }
+        );
+
+        $action = new StoreAction();
+        $action->setConfiguration($this->configuration);
+        $action->setOptions([
+            'event' => StoreAction::PRODUCT_HAS_CHANGES,
+            'identifier' => 'identifier',
+            'entity' => 'product',
+        ]);
+
+        $action->apply($item);
+
+        $this->assertCount(4, $calls);
+
+        $this->assertContains(
+            ['product_changes_fields_added', ['name']],
+            $calls
+        );
+    }
+
+    public function testDetectDeletedChanges()
+    {
+        $item = [
+            'identifier' => '123',
+            'values' => [],
+        ];
+
+        $this->changeManager->method('hasChanges')->willReturn(true);
+        $this->changeManager->method('getChanges')->willReturn([
+            'added' => [],
+            'deleted' => ['name'],
+            'updated' => [],
+            'all' => ['name'],
+        ]);
+
+
+        $this->configuration
+            ->method('updateList')
+            ->willReturnCallback(function (...$args) use (&$calls) {
+                $calls[] = $args;
+            }
+        );
+
+        $action = new StoreAction();
+        $action->setConfiguration($this->configuration);
+        $action->setOptions([
+            'event' => StoreAction::PRODUCT_HAS_CHANGES,
+            'identifier' => 'identifier',
+            'entity' => 'product',
+        ]);
+
+        $action->apply($item);
+
+        $this->assertCount(4, $calls);
+
+        $this->assertContains(
+            ['product_changes_fields_deleted', ['name']],
+            $calls
+        );
+    }
+
+    public function testDetectUpdatedChanges()
+    {
+        $item = [
+            'identifier' => '123',
+            'values' => ['name' => 'Updated Product'],
+        ];
+
+        $this->changeManager->method('hasChanges')->willReturn(true);
+        $this->changeManager->method('getChanges')->willReturn([
+            'added' => [],
+            'deleted' => [],
+            'updated' => ['name'],
+            'all' => ['name'],
+        ]);
+
+        $this->configuration
+            ->method('updateList')
+            ->willReturnCallback(function (...$args) use (&$calls) {
+                $calls[] = $args;
+            });
+
+        $action = new StoreAction();
+        $action->setConfiguration($this->configuration);
+        $action->setOptions([
+            'event' => StoreAction::PRODUCT_HAS_CHANGES,
+            'identifier' => 'identifier',
+            'entity' => 'product',
+            'true_action' => ['some_action'],
+        ]);
+
+        $trueActionProcessor = $this->createMock(ItemActionProcessor::class);
+        $trueActionProcessor->expects($this->once())
+            ->method('process')
+            ->with($item);
+
+        $this->configuration->expects($this->once())->method('generateActionProcessor')
+            ->willReturn($trueActionProcessor);
+
+        $action->apply($item);
+
+        $this->assertCount(4, $calls);
+
+        $this->assertContains(
+            ['product_changes_fields_updated', ['name']],
+            $calls
+        );
+        $this->assertContains(
+            ['product_changes_fields_deleted', []],
+            $calls
+        );
+        $this->assertContains(
+            ['product_changes_fields_added', []],
+            $calls
+        );
+    }
+}


### PR DESCRIPTION
StoreAction is hier uitgebreid met 3 nieuwe features, 

- **store_product**: boolean bepaald of je het product wenst te bewaren na evaluatie. default true.
- **strict_value_matching**: boolean bepaald de matching van values, lees ondersteuning op lege string waarden indien false, default true.
- fix op de `falseAction`, mag enkel in combinatie met `productHasChanges === false `en true+false actions in aparte `if` blokken, ifv leesbaarheid.
