### PR TITLE
AVA-101: improved: AkeneoItemBuilder, Item datastructures

### DIFF
--- a/src/Component/Akeneo/DataStructure/AkeneoItemBuilder.php
+++ b/src/Component/Akeneo/DataStructure/AkeneoItemBuilder.php
@@ -55,16 +55,13 @@ class AkeneoItemBuilder
             if ($property === 'values') {
                 continue;
             }
-            if (is_array($propertyValue)) {
-                $propertyValue['matcher'] = Matcher::create($property);
-            }
             $itemObj->addItem($property, $propertyValue);
         }
 
         // convert every value into an ItemNode
         foreach ($productData['values'] as $attributeCode => $productValues) {
             foreach ($productValues as $productValue) {
-                $matcher = Matcher::create('values|'.$attributeCode, $productValue['locale'], $productValue['scope']);
+                $matcher = Matcher::create('values|'.$attributeCode, $productValue['locale'] ?? null, $productValue['scope'] ?? $productValue['channel'] ?? null); # @todo channel is not part of the product API
                 // don't overwrite a type when it has been given
                 $productValue['type'] = $productValue['type'] ?? $attributeData[$matcher->getPrimaryKey()] ?? null;
                 $productValue['matcher'] = $matcher;

--- a/tests/Component/Akeneo/DataStructure/AkeneoItemBuilderTest.php
+++ b/tests/Component/Akeneo/DataStructure/AkeneoItemBuilderTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Misery\Component\Akeneo\DataStructure;
+
+use Misery\Component\Akeneo\DataStructure\AkeneoItemBuilder;
+use Misery\Component\Converter\Matcher;
+use Misery\Model\DataStructure\ItemInterface;
+use PHPUnit\Framework\TestCase;
+
+class AkeneoItemBuilderTest extends TestCase
+{
+    private array $productData = [
+        'identifier' => '1234',
+        'parent' => '5678',
+        'categories' => ['category1', 'category2'],
+        'values' => [
+            'weight' => [
+                [
+                    'locale' => null,
+                    'scope' => null,
+                    'data' => [
+                        'amount' => 1,
+                        'unit' => 'GRAM'
+                    ]
+                ]
+            ],
+            'color' => [
+                [
+                    'locale' => 'en_US',
+                    'scope' => 'ecom',
+                    'data' => 'red',
+                ]
+            ],
+            'brand' => [
+                [
+                    'locale' => 'en_US',
+                    'scope' => null,
+                    'data' => 'nike'
+                ]
+            ],
+        ],
+    ];
+
+    public function testFromProductApiPayload(): void
+    {
+        $productData = $this->productData;
+
+        $context = [
+            'attribute_types' => [
+                'weight' => 'metric',
+                'color' => 'simple_select',
+                'brand' => 'reference_data',
+            ],
+        ];
+
+        // Call the method
+        $item = AkeneoItemBuilder::fromProductApiPayload($productData, $context);
+
+        // Assertions
+        $this->assertInstanceOf(ItemInterface::class, $item);
+
+        $this->assertSame(['identifier', 'parent', 'categories', 'values|weight', 'values|color|en_US|ecom', 'values|brand|en_US'], $item->getItemCodes());
+        $colorData = $item->getItem('values|color|en_US|ecom')->getValue();
+
+        $this->assertEquals(
+            [
+                'locale' => 'en_US',
+                'scope' => 'ecom',
+                'type' => 'simple_select',
+                'matcher' => Matcher::create('values|color', 'en_US', 'ecom'),
+                'data' => 'red',
+            ],
+            $colorData
+        );
+
+        $weightData = $item->getItem('values|weight')->getValue();
+
+        $this->assertEquals(
+            [
+                'locale' => null,
+                'scope' => null,
+                'type' => 'metric',
+                'matcher' => Matcher::create('values|weight'),
+                'data' => [
+                    'amount' => 1,
+                    'unit' => 'GRAM'
+                ],
+            ],
+            $weightData
+        );
+
+        $categories = $item->getItem('categories')->getValue();
+
+        $this->assertEquals(
+            [
+                'category1',
+                'category2',
+            ],
+            $categories
+        );
+    }
+
+    public function testTwoDirectionalLoads()
+    {
+        $productData = $this->productData;
+
+        $context = [
+            'attribute_types' => [
+                'weight' => 'metric',
+                'color' => 'simple_select',
+                'brand' => 'reference_data',
+            ],
+        ];
+
+        // Call the method
+        $item = AkeneoItemBuilder::fromProductApiPayload($productData, $context);
+
+        $this->assertSame($productData, $item->toArray());
+    }
+
+    public function testFromCatalogApiPayload(): void
+    {
+        $catalogData = [
+            'code' => 'black',
+            'labels' => [
+                'nl_BE' => 'zwart',
+                'en_US' => 'black',
+            ]
+        ];
+
+        // Call the method
+        $item = AkeneoItemBuilder::fromCatalogApiPayload($catalogData, ['class' => 'attribute']);
+
+        // Assertions
+        $this->assertInstanceOf(ItemInterface::class, $item);
+
+        $this->assertSame(['code', 'labels|nl_BE', 'labels|en_US'], $item->getItemCodes());
+
+        $this->assertSame('black', $item->getItem('labels|en_US')->getDataValue());
+        $this->assertSame('zwart', $item->getItem('labels|nl_BE')->getDataValue());
+    }
+}


### PR DESCRIPTION
AVA has a ProductValueUpdaterExtension that mimics the old [https://github.com/induxx/akeneo_ava/blob/master/src/Induxx/Bundle/ConnectorBundle/Saver/Product/DefaultValuesUpdater.php](DefaultValuesUpdater), that relies heavily on akeneo Object calls like `$valueCollection->getByCodes()` this codes simulates this behaviour so that we stay true to original.

PS: Most of the code is adapted from multi-tool V2.1